### PR TITLE
opentracker: complete pending roadmap items + Windows runner

### DIFF
--- a/vibes/opentracker/backend/gateway/src/main/java/com/digitaltwin/gateway/controller/ExportController.java
+++ b/vibes/opentracker/backend/gateway/src/main/java/com/digitaltwin/gateway/controller/ExportController.java
@@ -1,0 +1,115 @@
+package com.digitaltwin.gateway.controller;
+
+import com.digitaltwin.gateway.proxy.GeospatialClient;
+import com.digitaltwin.shared.dto.AircraftPositionDto;
+import com.digitaltwin.shared.dto.SatellitePositionDto;
+import com.digitaltwin.shared.dto.VesselPositionDto;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/export")
+public class ExportController {
+
+    private final GeospatialClient geospatialClient;
+
+    public ExportController(GeospatialClient geospatialClient) {
+        this.geospatialClient = geospatialClient;
+    }
+
+    @GetMapping(value = "/flights.geojson", produces = "application/geo+json")
+    public ResponseEntity<Map<String, Object>> exportFlights(
+            @RequestParam(defaultValue = "-90") double minLat,
+            @RequestParam(defaultValue = "90") double maxLat,
+            @RequestParam(defaultValue = "-180") double minLon,
+            @RequestParam(defaultValue = "180") double maxLon) {
+        List<AircraftPositionDto> flights = geospatialClient.getFlights(minLat, maxLat, minLon, maxLon);
+        List<Map<String, Object>> features = flights.stream()
+                .map(f -> feature(f.lon(), f.lat(), Map.of(
+                        "id", nullSafe(f.id()),
+                        "icao24", nullSafe(f.icao24()),
+                        "callsign", nullSafe(f.callsign()),
+                        "timestamp", String.valueOf(f.timestamp()),
+                        "altitudeMeters", nullSafe(f.altitudeMeters()),
+                        "groundSpeedMps", nullSafe(f.groundSpeedMps()),
+                        "headingDeg", nullSafe(f.headingDeg()),
+                        "verticalRateMps", nullSafe(f.verticalRateMps())
+                )))
+                .collect(Collectors.toList());
+        return download("flights.geojson", featureCollection(features));
+    }
+
+    @GetMapping(value = "/ships.geojson", produces = "application/geo+json")
+    public ResponseEntity<Map<String, Object>> exportShips(
+            @RequestParam(defaultValue = "-90") double minLat,
+            @RequestParam(defaultValue = "90") double maxLat,
+            @RequestParam(defaultValue = "-180") double minLon,
+            @RequestParam(defaultValue = "180") double maxLon) {
+        List<VesselPositionDto> ships = geospatialClient.getShips(minLat, maxLat, minLon, maxLon);
+        List<Map<String, Object>> features = ships.stream()
+                .map(v -> feature(v.lon(), v.lat(), Map.of(
+                        "id", nullSafe(v.id()),
+                        "mmsi", nullSafe(v.mmsi()),
+                        "name", nullSafe(v.name()),
+                        "timestamp", String.valueOf(v.timestamp()),
+                        "speedKnots", nullSafe(v.speedKnots()),
+                        "courseDeg", nullSafe(v.courseDeg())
+                )))
+                .collect(Collectors.toList());
+        return download("ships.geojson", featureCollection(features));
+    }
+
+    @GetMapping(value = "/satellites.geojson", produces = "application/geo+json")
+    public ResponseEntity<Map<String, Object>> exportSatellites() {
+        List<SatellitePositionDto> sats = geospatialClient.getSatellites();
+        List<Map<String, Object>> features = sats.stream()
+                .map(s -> feature(s.lon(), s.lat(), Map.of(
+                        "noradId", nullSafe(s.noradId()),
+                        "name", nullSafe(s.name()),
+                        "timestamp", String.valueOf(s.timestamp()),
+                        "altitudeKm", nullSafe(s.altitudeKm()),
+                        "velocityKmS", nullSafe(s.velocityKmS())
+                )))
+                .collect(Collectors.toList());
+        return download("satellites.geojson", featureCollection(features));
+    }
+
+    private static Map<String, Object> feature(double lon, double lat, Map<String, Object> props) {
+        Map<String, Object> geom = new LinkedHashMap<>();
+        geom.put("type", "Point");
+        geom.put("coordinates", List.of(lon, lat));
+        Map<String, Object> feat = new LinkedHashMap<>();
+        feat.put("type", "Feature");
+        feat.put("geometry", geom);
+        feat.put("properties", props);
+        return feat;
+    }
+
+    private static Map<String, Object> featureCollection(List<Map<String, Object>> features) {
+        Map<String, Object> fc = new LinkedHashMap<>();
+        fc.put("type", "FeatureCollection");
+        fc.put("features", features);
+        return fc;
+    }
+
+    private static Object nullSafe(Object value) {
+        return value == null ? "" : value;
+    }
+
+    private static ResponseEntity<Map<String, Object>> download(String filename, Map<String, Object> body) {
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + filename + "\"")
+                .contentType(MediaType.parseMediaType("application/geo+json"))
+                .body(body);
+    }
+}

--- a/vibes/opentracker/backend/stream-processor/src/main/resources/db/migration/V3__timescaledb_optional.sql
+++ b/vibes/opentracker/backend/stream-processor/src/main/resources/db/migration/V3__timescaledb_optional.sql
@@ -1,0 +1,54 @@
+-- Optional TimescaleDB hypertable conversion.
+--
+-- This migration is a no-op on stock PostgreSQL and only takes effect when the
+-- TimescaleDB extension is available (e.g. when the postgres image is swapped
+-- for `timescale/timescaledb-ha:pg16`). It converts the position tables into
+-- hypertables for chunk-based time partitioning, automatic chunk pruning, and
+-- per-chunk compression — without any application code changes.
+--
+-- The DO block guards every statement so the migration succeeds against a
+-- vanilla PostgreSQL 16 + PostGIS image as well.
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'timescaledb') THEN
+        CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;
+
+        -- Hypertable conversion is idempotent thanks to if_not_exists => TRUE.
+        PERFORM create_hypertable(
+            'aircraft_positions',
+            'recorded_at',
+            chunk_time_interval => INTERVAL '1 day',
+            migrate_data        => TRUE,
+            if_not_exists       => TRUE
+        );
+
+        PERFORM create_hypertable(
+            'vessel_positions',
+            'recorded_at',
+            chunk_time_interval => INTERVAL '1 day',
+            migrate_data        => TRUE,
+            if_not_exists       => TRUE
+        );
+
+        -- Compression policy: compress chunks older than 7 days. Saves >90% on
+        -- typical position data while leaving the hot window uncompressed.
+        BEGIN
+            EXECUTE 'ALTER TABLE aircraft_positions SET (timescaledb.compress, '
+                  || 'timescaledb.compress_segmentby = ''aircraft_id'')';
+            PERFORM add_compression_policy('aircraft_positions', INTERVAL '7 days', if_not_exists => TRUE);
+        EXCEPTION WHEN OTHERS THEN
+            -- Older Timescale versions may not expose all options; ignore so the
+            -- migration remains idempotent across deployment targets.
+            NULL;
+        END;
+
+        BEGIN
+            EXECUTE 'ALTER TABLE vessel_positions SET (timescaledb.compress, '
+                  || 'timescaledb.compress_segmentby = ''vessel_id'')';
+            PERFORM add_compression_policy('vessel_positions', INTERVAL '7 days', if_not_exists => TRUE);
+        EXCEPTION WHEN OTHERS THEN
+            NULL;
+        END;
+    END IF;
+END$$;

--- a/vibes/opentracker/frontend/digital-twin-earth-app/src/app/globe/globe.component.html
+++ b/vibes/opentracker/frontend/digital-twin-earth-app/src/app/globe/globe.component.html
@@ -163,6 +163,7 @@
       [showTerrain]="showTerrain"
       [showBuildings]="showBuildings"
       [showWeather]="showWeather"
+      [showAirports]="showAirports"
       (layerToggled)="onLayerToggle($event)">
     </app-layer-toggle>
 

--- a/vibes/opentracker/frontend/digital-twin-earth-app/src/app/globe/globe.component.ts
+++ b/vibes/opentracker/frontend/digital-twin-earth-app/src/app/globe/globe.component.ts
@@ -64,6 +64,7 @@ export class GlobeComponent implements OnInit, OnDestroy {
   showTerrain       = true;
   showBuildings     = false;
   showWeather       = false;
+  showAirports      = false;
   connectionStatus: ConnectionStatus = 'connecting';
   isStreetView = false;
   usingMockData = false;
@@ -300,6 +301,9 @@ export class GlobeComponent implements OnInit, OnDestroy {
         }
         this.cdr.markForCheck();
       });
+    } else if (event.layer === 'airports') {
+      this.showAirports = event.visible;
+      this.globe.setAirportsVisible(event.visible);
     } else if (event.layer === 'weather') {
       this.showWeather = event.visible;
       void this.globe.setWeatherVisible(event.visible).then(() => {
@@ -396,6 +400,9 @@ export class GlobeComponent implements OnInit, OnDestroy {
         break;
       case 'h':
         this.globe.zoomToHome();
+        break;
+      case 'a':
+        this.onLayerToggle({ layer: 'airports', visible: !this.showAirports });
         break;
       case 'r':
         this.globe.recoverEarthViewIfNeeded();

--- a/vibes/opentracker/frontend/digital-twin-earth-app/src/app/globe/layer-toggle/layer-toggle.component.html
+++ b/vibes/opentracker/frontend/digital-twin-earth-app/src/app/globe/layer-toggle/layer-toggle.component.html
@@ -199,5 +199,35 @@
       </label>
     </div>
 
+    <div class="layer-separator" aria-hidden="true"></div>
+
+    <!-- Airports layer -->
+    <div class="layer-row" [class.layer-row--active]="showAirports">
+      <div class="layer-meta">
+        <span class="layer-indicator layer-indicator--airports" aria-hidden="true">
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+            <path d="M7 1L8.4 5.5L13 7L8.4 8.5L7 13L5.6 8.5L1 7L5.6 5.5L7 1Z"
+                  fill="currentColor" opacity="0.92"/>
+          </svg>
+        </span>
+        <div class="layer-text">
+          <span class="layer-name">Airports</span>
+          <span class="layer-desc">Major international hubs</span>
+        </div>
+      </div>
+
+      <label class="ios-toggle ios-toggle--orange" [attr.aria-label]="'Toggle airports layer'">
+        <input
+          type="checkbox"
+          [checked]="showAirports"
+          (change)="toggle('airports', $event)"
+          role="switch"
+          [attr.aria-checked]="showAirports">
+        <span class="ios-toggle__track">
+          <span class="ios-toggle__thumb"></span>
+        </span>
+      </label>
+    </div>
+
   </div>
 </div>

--- a/vibes/opentracker/frontend/digital-twin-earth-app/src/app/globe/layer-toggle/layer-toggle.component.scss
+++ b/vibes/opentracker/frontend/digital-twin-earth-app/src/app/globe/layer-toggle/layer-toggle.component.scss
@@ -145,6 +145,16 @@
       box-shadow: 0 0 10px rgba(191, 90, 242, 0.25);
     }
   }
+
+  &--airports {
+    background: rgba(255, 159, 10, 0.16);
+    color: #FFB340;
+
+    .layer-row--active & {
+      background: rgba(255, 159, 10, 0.26);
+      box-shadow: 0 0 10px rgba(255, 159, 10, 0.30);
+    }
+  }
 }
 
 .layer-text {

--- a/vibes/opentracker/frontend/digital-twin-earth-app/src/app/globe/layer-toggle/layer-toggle.component.ts
+++ b/vibes/opentracker/frontend/digital-twin-earth-app/src/app/globe/layer-toggle/layer-toggle.component.ts
@@ -27,6 +27,7 @@ export class LayerToggleComponent {
   @Input() showTerrain    = true;
   @Input() showBuildings  = false;
   @Input() showWeather    = false;
+  @Input() showAirports   = false;
 
   @Output() layerToggled = new EventEmitter<LayerToggleEvent>();
 

--- a/vibes/opentracker/frontend/digital-twin-earth-app/src/app/globe/stats-panel/stats-panel.component.html
+++ b/vibes/opentracker/frontend/digital-twin-earth-app/src/app/globe/stats-panel/stats-panel.component.html
@@ -83,6 +83,35 @@
 
   </div>
 
+  <!-- Export row -->
+  <div class="export-row" role="group" aria-label="Export current snapshot as GeoJSON">
+    <span class="export-label">Export</span>
+    <button class="export-btn export-btn--flights"
+            type="button"
+            [disabled]="exporting !== null"
+            (click)="exportLayer('flights')"
+            title="Download current flight snapshot as GeoJSON">
+      <span class="export-dot" aria-hidden="true"></span>
+      {{ exporting === 'flights' ? '…' : 'Flights' }}
+    </button>
+    <button class="export-btn export-btn--ships"
+            type="button"
+            [disabled]="exporting !== null"
+            (click)="exportLayer('ships')"
+            title="Download current vessel snapshot as GeoJSON">
+      <span class="export-dot" aria-hidden="true"></span>
+      {{ exporting === 'ships' ? '…' : 'Ships' }}
+    </button>
+    <button class="export-btn export-btn--sats"
+            type="button"
+            [disabled]="exporting !== null"
+            (click)="exportLayer('satellites')"
+            title="Download current satellite snapshot as GeoJSON">
+      <span class="export-dot" aria-hidden="true"></span>
+      {{ exporting === 'satellites' ? '…' : 'Sats' }}
+    </button>
+  </div>
+
   <!-- Last updated timestamp -->
   @if (lastUpdated) {
     <p class="last-updated">

--- a/vibes/opentracker/frontend/digital-twin-earth-app/src/app/globe/stats-panel/stats-panel.component.scss
+++ b/vibes/opentracker/frontend/digital-twin-earth-app/src/app/globe/stats-panel/stats-panel.component.scss
@@ -189,6 +189,69 @@
 }
 
 // ============================================================
+// Export row
+// ============================================================
+.export-row {
+  margin-top: 14px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.export-label {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+  color: var(--color-text-quaternary, rgba(255, 255, 255, 0.55));
+  margin-right: 2px;
+}
+
+.export-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.92);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.2px;
+  cursor: pointer;
+  transition: background 160ms ease, transform 160ms ease, border-color 160ms ease;
+
+  &:hover:not(:disabled) {
+    background: rgba(255, 255, 255, 0.12);
+    border-color: rgba(255, 255, 255, 0.22);
+    transform: translateY(-1px);
+  }
+
+  &:active:not(:disabled) {
+    transform: translateY(0);
+  }
+
+  &:disabled {
+    opacity: 0.55;
+    cursor: progress;
+  }
+}
+
+.export-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  display: inline-block;
+}
+
+.export-btn--flights .export-dot { color: #0A84FF; }
+.export-btn--ships   .export-dot { color: #30D158; }
+.export-btn--sats    .export-dot { color: #FFD60A; }
+
+// ============================================================
 // Last Updated
 // ============================================================
 .last-updated {

--- a/vibes/opentracker/frontend/digital-twin-earth-app/src/app/globe/stats-panel/stats-panel.component.ts
+++ b/vibes/opentracker/frontend/digital-twin-earth-app/src/app/globe/stats-panel/stats-panel.component.ts
@@ -24,6 +24,31 @@ export class StatsPanelComponent implements OnChanges {
 
   lastUpdated: Date | null = null;
   totalEntities             = 0;
+  exporting: 'flights' | 'ships' | 'satellites' | null = null;
+
+  exportLayer(kind: 'flights' | 'ships' | 'satellites'): void {
+    if (this.exporting) return;
+    this.exporting = kind;
+
+    const url = `/api/export/${kind}.geojson`;
+    fetch(url, { headers: { 'X-Api-Key': 'dev-key' } })
+      .then(r => r.ok ? r.blob() : Promise.reject(new Error('Export failed')))
+      .then(blob => {
+        const a = document.createElement('a');
+        a.href = URL.createObjectURL(blob);
+        a.download = `${kind}-${new Date().toISOString().slice(0, 19).replace(/[:T]/g, '-')}.geojson`;
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        URL.revokeObjectURL(a.href);
+      })
+      .catch(() => {
+        // Silent fall-through; the live-badge surface already conveys connectivity issues.
+      })
+      .finally(() => {
+        this.exporting = null;
+      });
+  }
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['flightCount'] || changes['shipCount'] || changes['satelliteCount']) {

--- a/vibes/opentracker/frontend/digital-twin-earth-app/src/app/services/airports.data.ts
+++ b/vibes/opentracker/frontend/digital-twin-earth-app/src/app/services/airports.data.ts
@@ -1,0 +1,91 @@
+/**
+ * Curated subset of major international airports.
+ * Source: OurAirports public-domain dataset (https://ourairports.com/data/).
+ * Field shape mirrors the OurAirports CSV: iata, icao, name, lat, lon, size.
+ */
+export interface Airport {
+  iata: string;
+  icao: string;
+  name: string;
+  city: string;
+  country: string;
+  lat: number;
+  lon: number;
+  size: 'large' | 'medium';
+}
+
+export const MAJOR_AIRPORTS: Airport[] = [
+  { iata: 'ATL', icao: 'KATL', name: 'Hartsfield–Jackson Atlanta',     city: 'Atlanta',       country: 'US', lat: 33.6407,  lon: -84.4277,  size: 'large' },
+  { iata: 'PEK', icao: 'ZBAA', name: 'Beijing Capital',                 city: 'Beijing',       country: 'CN', lat: 40.0801,  lon: 116.5846,  size: 'large' },
+  { iata: 'LAX', icao: 'KLAX', name: 'Los Angeles Intl',                city: 'Los Angeles',   country: 'US', lat: 33.9416,  lon: -118.4085, size: 'large' },
+  { iata: 'DXB', icao: 'OMDB', name: 'Dubai Intl',                      city: 'Dubai',         country: 'AE', lat: 25.2532,  lon: 55.3657,   size: 'large' },
+  { iata: 'HND', icao: 'RJTT', name: 'Tokyo Haneda',                    city: 'Tokyo',         country: 'JP', lat: 35.5523,  lon: 139.7798,  size: 'large' },
+  { iata: 'ORD', icao: 'KORD', name: 'O’Hare Intl',                city: 'Chicago',       country: 'US', lat: 41.9786,  lon: -87.9048,  size: 'large' },
+  { iata: 'LHR', icao: 'EGLL', name: 'London Heathrow',                 city: 'London',        country: 'GB', lat: 51.4700,  lon: -0.4543,   size: 'large' },
+  { iata: 'PVG', icao: 'ZSPD', name: 'Shanghai Pudong',                 city: 'Shanghai',      country: 'CN', lat: 31.1443,  lon: 121.8083,  size: 'large' },
+  { iata: 'CDG', icao: 'LFPG', name: 'Paris Charles de Gaulle',         city: 'Paris',         country: 'FR', lat: 49.0097,  lon: 2.5479,    size: 'large' },
+  { iata: 'DFW', icao: 'KDFW', name: 'Dallas/Fort Worth',               city: 'Dallas',        country: 'US', lat: 32.8998,  lon: -97.0403,  size: 'large' },
+  { iata: 'AMS', icao: 'EHAM', name: 'Amsterdam Schiphol',              city: 'Amsterdam',     country: 'NL', lat: 52.3105,  lon: 4.7683,    size: 'large' },
+  { iata: 'FRA', icao: 'EDDF', name: 'Frankfurt am Main',               city: 'Frankfurt',     country: 'DE', lat: 50.0379,  lon: 8.5622,    size: 'large' },
+  { iata: 'IST', icao: 'LTFM', name: 'Istanbul',                        city: 'Istanbul',      country: 'TR', lat: 41.2753,  lon: 28.7519,   size: 'large' },
+  { iata: 'CAN', icao: 'ZGGG', name: 'Guangzhou Baiyun',                city: 'Guangzhou',     country: 'CN', lat: 23.3924,  lon: 113.2988,  size: 'large' },
+  { iata: 'SIN', icao: 'WSSS', name: 'Singapore Changi',                city: 'Singapore',     country: 'SG', lat: 1.3644,   lon: 103.9915,  size: 'large' },
+  { iata: 'DEL', icao: 'VIDP', name: 'Indira Gandhi Intl',              city: 'Delhi',         country: 'IN', lat: 28.5562,  lon: 77.1000,   size: 'large' },
+  { iata: 'BOM', icao: 'VABB', name: 'Chhatrapati Shivaji Maharaj',     city: 'Mumbai',        country: 'IN', lat: 19.0896,  lon: 72.8656,   size: 'large' },
+  { iata: 'ICN', icao: 'RKSI', name: 'Incheon Intl',                    city: 'Seoul',         country: 'KR', lat: 37.4691,  lon: 126.4505,  size: 'large' },
+  { iata: 'JFK', icao: 'KJFK', name: 'John F. Kennedy Intl',            city: 'New York',      country: 'US', lat: 40.6413,  lon: -73.7781,  size: 'large' },
+  { iata: 'DEN', icao: 'KDEN', name: 'Denver Intl',                     city: 'Denver',        country: 'US', lat: 39.8561,  lon: -104.6737, size: 'large' },
+  { iata: 'SFO', icao: 'KSFO', name: 'San Francisco Intl',              city: 'San Francisco', country: 'US', lat: 37.6213,  lon: -122.3790, size: 'large' },
+  { iata: 'SEA', icao: 'KSEA', name: 'Seattle–Tacoma',             city: 'Seattle',       country: 'US', lat: 47.4502,  lon: -122.3088, size: 'large' },
+  { iata: 'MIA', icao: 'KMIA', name: 'Miami Intl',                      city: 'Miami',         country: 'US', lat: 25.7959,  lon: -80.2870,  size: 'large' },
+  { iata: 'YYZ', icao: 'CYYZ', name: 'Toronto Pearson',                 city: 'Toronto',       country: 'CA', lat: 43.6777,  lon: -79.6248,  size: 'large' },
+  { iata: 'GRU', icao: 'SBGR', name: 'São Paulo Guarulhos',         city: 'São Paulo',         country: 'BR', lat: -23.4356, lon: -46.4731,  size: 'large' },
+  { iata: 'MEX', icao: 'MMMX', name: 'Mexico City',                     city: 'Mexico City',   country: 'MX', lat: 19.4361,  lon: -99.0719,  size: 'large' },
+  { iata: 'EZE', icao: 'SAEZ', name: 'Buenos Aires Ezeiza',             city: 'Buenos Aires',  country: 'AR', lat: -34.8222, lon: -58.5358,  size: 'large' },
+  { iata: 'JNB', icao: 'FAOR', name: 'O. R. Tambo Intl',                city: 'Johannesburg',  country: 'ZA', lat: -26.1392, lon: 28.2460,   size: 'large' },
+  { iata: 'CAI', icao: 'HECA', name: 'Cairo Intl',                      city: 'Cairo',         country: 'EG', lat: 30.1219,  lon: 31.4056,   size: 'large' },
+  { iata: 'SYD', icao: 'YSSY', name: 'Sydney Kingsford Smith',          city: 'Sydney',        country: 'AU', lat: -33.9399, lon: 151.1753,  size: 'large' },
+  { iata: 'AKL', icao: 'NZAA', name: 'Auckland',                        city: 'Auckland',      country: 'NZ', lat: -37.0082, lon: 174.7917,  size: 'large' },
+  { iata: 'MAD', icao: 'LEMD', name: 'Adolfo Suárez Madrid–Barajas', city: 'Madrid', country: 'ES', lat: 40.4936,  lon: -3.5668,   size: 'large' },
+  { iata: 'BCN', icao: 'LEBL', name: 'Barcelona–El Prat',          city: 'Barcelona',     country: 'ES', lat: 41.2974,  lon: 2.0833,    size: 'large' },
+  { iata: 'FCO', icao: 'LIRF', name: 'Rome Fiumicino',                  city: 'Rome',          country: 'IT', lat: 41.8003,  lon: 12.2389,   size: 'large' },
+  { iata: 'MUC', icao: 'EDDM', name: 'Munich',                          city: 'Munich',        country: 'DE', lat: 48.3538,  lon: 11.7861,   size: 'large' },
+  { iata: 'ZRH', icao: 'LSZH', name: 'Zürich',                     city: 'Zurich',        country: 'CH', lat: 47.4647,  lon: 8.5492,    size: 'large' },
+  { iata: 'ARN', icao: 'ESSA', name: 'Stockholm Arlanda',               city: 'Stockholm',     country: 'SE', lat: 59.6519,  lon: 17.9186,   size: 'large' },
+  { iata: 'SVO', icao: 'UUEE', name: 'Sheremetyevo',                    city: 'Moscow',        country: 'RU', lat: 55.9726,  lon: 37.4146,   size: 'large' },
+  { iata: 'BKK', icao: 'VTBS', name: 'Suvarnabhumi',                    city: 'Bangkok',       country: 'TH', lat: 13.6900,  lon: 100.7501,  size: 'large' },
+  { iata: 'KUL', icao: 'WMKK', name: 'Kuala Lumpur Intl',               city: 'Kuala Lumpur',  country: 'MY', lat: 2.7456,   lon: 101.7099,  size: 'large' },
+  { iata: 'CGK', icao: 'WIII', name: 'Soekarno–Hatta',             city: 'Jakarta',       country: 'ID', lat: -6.1256,  lon: 106.6559,  size: 'large' },
+  { iata: 'MNL', icao: 'RPLL', name: 'Ninoy Aquino Intl',               city: 'Manila',        country: 'PH', lat: 14.5086,  lon: 121.0194,  size: 'large' },
+  { iata: 'HKG', icao: 'VHHH', name: 'Hong Kong Intl',                  city: 'Hong Kong',     country: 'HK', lat: 22.3080,  lon: 113.9185,  size: 'large' },
+  { iata: 'TPE', icao: 'RCTP', name: 'Taoyuan Intl',                    city: 'Taipei',        country: 'TW', lat: 25.0797,  lon: 121.2342,  size: 'large' },
+  { iata: 'BOS', icao: 'KBOS', name: 'Boston Logan',                    city: 'Boston',        country: 'US', lat: 42.3656,  lon: -71.0096,  size: 'large' },
+  { iata: 'PHX', icao: 'KPHX', name: 'Phoenix Sky Harbor',              city: 'Phoenix',       country: 'US', lat: 33.4342,  lon: -112.0116, size: 'large' },
+  { iata: 'LAS', icao: 'KLAS', name: 'Harry Reid Intl',                 city: 'Las Vegas',     country: 'US', lat: 36.0840,  lon: -115.1537, size: 'large' },
+  { iata: 'IAH', icao: 'KIAH', name: 'George Bush Intercontinental',    city: 'Houston',       country: 'US', lat: 29.9902,  lon: -95.3368,  size: 'large' },
+  { iata: 'YVR', icao: 'CYVR', name: 'Vancouver Intl',                  city: 'Vancouver',     country: 'CA', lat: 49.1939,  lon: -123.1844, size: 'large' },
+  { iata: 'DOH', icao: 'OTHH', name: 'Hamad Intl',                      city: 'Doha',          country: 'QA', lat: 25.2731,  lon: 51.6080,   size: 'large' },
+  { iata: 'AUH', icao: 'OMAA', name: 'Abu Dhabi Intl',                  city: 'Abu Dhabi',     country: 'AE', lat: 24.4330,  lon: 54.6511,   size: 'large' },
+  { iata: 'JED', icao: 'OEJN', name: 'King Abdulaziz Intl',             city: 'Jeddah',        country: 'SA', lat: 21.6796,  lon: 39.1565,   size: 'large' },
+  { iata: 'TLV', icao: 'LLBG', name: 'Ben Gurion',                      city: 'Tel Aviv',      country: 'IL', lat: 32.0114,  lon: 34.8867,   size: 'large' },
+  { iata: 'ADD', icao: 'HAAB', name: 'Addis Ababa Bole',                city: 'Addis Ababa',   country: 'ET', lat: 8.9779,   lon: 38.7993,   size: 'large' },
+  { iata: 'NBO', icao: 'HKJK', name: 'Jomo Kenyatta Intl',              city: 'Nairobi',       country: 'KE', lat: -1.3192,  lon: 36.9278,   size: 'large' },
+  { iata: 'LOS', icao: 'DNMM', name: 'Murtala Muhammed',                city: 'Lagos',         country: 'NG', lat: 6.5774,   lon: 3.3211,    size: 'large' },
+  { iata: 'CMN', icao: 'GMMN', name: 'Mohammed V',                      city: 'Casablanca',    country: 'MA', lat: 33.3675,  lon: -7.5897,   size: 'large' },
+  { iata: 'GIG', icao: 'SBGL', name: 'Rio de Janeiro Galeão',      city: 'Rio de Janeiro',country: 'BR', lat: -22.8120, lon: -43.2506,  size: 'large' },
+  { iata: 'BOG', icao: 'SKBO', name: 'El Dorado Intl',                  city: 'Bogotá',   country: 'CO', lat: 4.7016,   lon: -74.1469,  size: 'large' },
+  { iata: 'SCL', icao: 'SCEL', name: 'Arturo Merino Benítez',      city: 'Santiago',      country: 'CL', lat: -33.3898, lon: -70.7944,  size: 'large' },
+  { iata: 'LIM', icao: 'SPJC', name: 'Jorge Chávez Intl',          city: 'Lima',          country: 'PE', lat: -12.0219, lon: -77.1143,  size: 'large' },
+  { iata: 'MEL', icao: 'YMML', name: 'Melbourne Tullamarine',           city: 'Melbourne',     country: 'AU', lat: -37.6690, lon: 144.8410,  size: 'large' },
+  { iata: 'PER', icao: 'YPPH', name: 'Perth',                           city: 'Perth',         country: 'AU', lat: -31.9403, lon: 115.9669,  size: 'large' },
+  { iata: 'KEF', icao: 'BIKF', name: 'Keflavík Intl',              city: 'Reykjavík',country: 'IS', lat: 63.9850,  lon: -22.6056,  size: 'large' },
+  { iata: 'OSL', icao: 'ENGM', name: 'Oslo Gardermoen',                 city: 'Oslo',          country: 'NO', lat: 60.1939,  lon: 11.1004,   size: 'large' },
+  { iata: 'CPH', icao: 'EKCH', name: 'Copenhagen Kastrup',              city: 'Copenhagen',    country: 'DK', lat: 55.6180,  lon: 12.6508,   size: 'large' },
+  { iata: 'DUB', icao: 'EIDW', name: 'Dublin',                          city: 'Dublin',        country: 'IE', lat: 53.4213,  lon: -6.2701,   size: 'large' },
+  { iata: 'WAW', icao: 'EPWA', name: 'Warsaw Chopin',                   city: 'Warsaw',        country: 'PL', lat: 52.1657,  lon: 20.9671,   size: 'large' },
+  { iata: 'PRG', icao: 'LKPR', name: 'Václav Havel',               city: 'Prague',        country: 'CZ', lat: 50.1008,  lon: 14.2600,   size: 'large' },
+  { iata: 'VIE', icao: 'LOWW', name: 'Vienna Intl',                     city: 'Vienna',        country: 'AT', lat: 48.1103,  lon: 16.5697,   size: 'large' },
+  { iata: 'BRU', icao: 'EBBR', name: 'Brussels',                        city: 'Brussels',      country: 'BE', lat: 50.9014,  lon: 4.4844,    size: 'large' },
+  { iata: 'LIS', icao: 'LPPT', name: 'Humberto Delgado',                city: 'Lisbon',        country: 'PT', lat: 38.7813,  lon: -9.1359,   size: 'large' },
+  { iata: 'ATH', icao: 'LGAV', name: 'Athens Eleftherios Venizelos',    city: 'Athens',        country: 'GR', lat: 37.9364,  lon: 23.9445,   size: 'large' },
+];

--- a/vibes/opentracker/frontend/digital-twin-earth-app/src/app/services/globe-engine.service.ts
+++ b/vibes/opentracker/frontend/digital-twin-earth-app/src/app/services/globe-engine.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { AircraftPositionDto, TrackPoint } from '../models/aircraft.model';
 import { VesselPositionDto } from '../models/vessel.model';
 import { SatellitePositionDto } from '../models/satellite.model';
+import { MAJOR_AIRPORTS } from './airports.data';
 
 // CesiumJS is loaded as a global <script> via angular.json.
 // Declaring it as `any` avoids requiring the @types/cesium package
@@ -18,6 +19,8 @@ export class GlobeEngineService {
   private readonly satelliteEntities = new Map<string, any>(); // keyed by noradId
   private readonly weatherEntities   = new Map<string, any>(); // keyed by weather id
   private readonly streetEntities    = new Map<string, any>(); // keyed by osm id
+  private readonly airportEntities   = new Map<string, any>(); // keyed by icao
+  private airportsEnabled = false;
   private baseImageryLayer: any | null = null; // eslint-disable-line @typescript-eslint/no-explicit-any
   private nightImageryLayer: any | null = null; // eslint-disable-line @typescript-eslint/no-explicit-any
 
@@ -1075,6 +1078,71 @@ export class GlobeEngineService {
     return this.buildingsState === 'ready';
   }
 
+  // ── Airports ───────────────────────────────────────────────
+
+  setAirportsVisible(visible: boolean): void {
+    if (!this.viewer) return;
+    this.airportsEnabled = visible;
+
+    if (visible) {
+      if (this.airportEntities.size === 0) {
+        this.seedAirports();
+      } else {
+        this.airportEntities.forEach(entity => entity.show = true);
+      }
+    } else {
+      this.airportEntities.forEach(entity => entity.show = false);
+    }
+  }
+
+  private seedAirports(): void {
+    const fillColor    = Cesium.Color.fromCssColorString('#FF9F0A').withAlpha(0.95);
+    const outlineColor = Cesium.Color.fromCssColorString('#FFFFFF').withAlpha(0.4);
+
+    MAJOR_AIRPORTS.forEach(ap => {
+      const entity = this.viewer.entities.add({
+        id:        `airport-${ap.icao}`,
+        name:      ap.name,
+        position:  Cesium.Cartesian3.fromDegrees(ap.lon, ap.lat, 0),
+        point: {
+          pixelSize:    7,
+          color:        fillColor,
+          outlineColor,
+          outlineWidth: 1.5,
+          heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
+          scaleByDistance: new Cesium.NearFarScalar(1e5, 1.5, 2e7, 0.55),
+          disableDepthTestDistance: Number.POSITIVE_INFINITY,
+        },
+        label: {
+          text: ap.iata,
+          font: '600 11px -apple-system, "SF Pro Text", sans-serif',
+          fillColor:        Cesium.Color.fromCssColorString('#FFCC80'),
+          outlineColor:     Cesium.Color.BLACK.withAlpha(0.65),
+          outlineWidth:     2,
+          style:            Cesium.LabelStyle.FILL_AND_OUTLINE,
+          pixelOffset:      new Cesium.Cartesian2(0, -16),
+          distanceDisplayCondition: new Cesium.DistanceDisplayCondition(0, 5e6),
+          showBackground:   true,
+          backgroundColor:  Cesium.Color.fromCssColorString('#1a1206').withAlpha(0.78),
+          backgroundPadding: new Cesium.Cartesian2(6, 3),
+          horizontalOrigin: Cesium.HorizontalOrigin.CENTER,
+          verticalOrigin:   Cesium.VerticalOrigin.BOTTOM,
+          disableDepthTestDistance: Number.POSITIVE_INFINITY,
+        },
+        description: `<div style="font-family:-apple-system,sans-serif;color:#fff">
+            <strong>${ap.name}</strong><br/>
+            ${ap.city}, ${ap.country}<br/>
+            IATA: ${ap.iata} · ICAO: ${ap.icao}
+          </div>`,
+      });
+      this.airportEntities.set(ap.icao, entity);
+    });
+  }
+
+  get hasAirports(): boolean {
+    return this.airportsEnabled;
+  }
+
   // ── Lifecycle ──────────────────────────────────────────────
 
   destroy(): void {
@@ -1087,6 +1155,7 @@ export class GlobeEngineService {
     this.trackEntities.clear();
     this.satelliteEntities.clear();
     this.weatherEntities.clear();
+    this.airportEntities.clear();
     this.baseImageryLayer = null;
     this.nightImageryLayer = null;
   }

--- a/vibes/opentracker/run.bat
+++ b/vibes/opentracker/run.bat
@@ -1,0 +1,279 @@
+@echo off
+setlocal EnableDelayedExpansion
+
+rem ============================================================================
+rem  Digital Twin Earth — Windows Runner
+rem  Mirrors run.sh: builds Docker images, writes deploy\.env, manages stack.
+rem  Usage: run.bat [mock] [up^|down^|restart^|logs^|status^|build^|clean^|help]
+rem ============================================================================
+
+set "SCRIPT_DIR=%~dp0"
+pushd "%SCRIPT_DIR%" >nul
+set "COMPOSE_FILE=deploy\docker-compose.yml"
+
+rem ─── Parse args (optional `mock` prefix + command) ──────────────────────────
+set "MOCK_MODE=false"
+set "ARG1=%~1"
+set "ARG2=%~2"
+set "CMD=up"
+
+if /I "%ARG1%"=="mock" (
+    set "MOCK_MODE=true"
+    if not "%ARG2%"=="" set "CMD=%ARG2%"
+) else (
+    if not "%ARG1%"=="" set "CMD=%ARG1%"
+)
+
+echo.
+echo Digital Twin Earth — Local Runner ^(Windows^)
+echo ============================================================
+echo.
+
+if /I "%CMD%"=="help"   goto :usage
+if /I "%CMD%"=="--help" goto :usage
+if /I "%CMD%"=="-h"     goto :usage
+if /I "%CMD%"=="up"      goto :do_up
+if /I "%CMD%"=="down"    goto :do_down
+if /I "%CMD%"=="restart" goto :do_restart
+if /I "%CMD%"=="build"   goto :do_build
+if /I "%CMD%"=="logs"    goto :do_logs
+if /I "%CMD%"=="status"  goto :do_status
+if /I "%CMD%"=="clean"   goto :do_clean
+
+echo [X] Unknown command: %CMD%
+echo.
+goto :usage
+
+rem ============================================================================
+:usage
+echo Usage: run.bat [mode] [command]
+echo.
+echo Modes ^(optional^):
+echo   mock       Force all feeds to mock/simulated data ^(no internet required^)
+echo.
+echo Commands:
+echo   up         Build images and start all services ^(default^)
+echo   down       Stop and remove all containers
+echo   restart    Stop then start
+echo   logs       Follow logs from all services
+echo   status     Show container status
+echo   build      Build Docker images only ^(no start^)
+echo   clean      Stop containers and remove volumes ^(destructive^)
+echo   help       Show this help
+echo.
+echo Examples:
+echo   run.bat up
+echo   run.bat mock up
+echo   run.bat down
+echo.
+echo   set MOCK_FLIGHTS_COUNT=20000 ^&^& set MOCK_SHIPS_COUNT=10000 ^&^& run.bat mock up
+echo.
+echo   set INGESTION_FEED_FLIGHT=opensky ^&^& set INGESTION_FEED_SHIP=aisstream ^&^& ^
+set AISSTREAM_API_KEY=your-key ^&^& run.bat up
+echo.
+echo Environment variables:
+echo   MOCK_SEED              Random seed for mock data ^(default: 42^)
+echo   MOCK_FLIGHTS_COUNT     Mock aircraft count ^(default: 500^)
+echo   MOCK_SHIPS_COUNT       Mock vessel count ^(default: 200^)
+echo   MOCK_SATELLITES_COUNT  Mock satellite count ^(default: 100^)
+echo   AISSTREAM_API_KEY      AISStream.io key ^(required for real ships^)
+echo   OPENSKY_USERNAME       OpenSky username
+echo   OPENSKY_PASSWORD       OpenSky password
+echo   GATEWAY_API_KEY        Gateway API key ^(default: dev-key^)
+goto :end
+
+rem ============================================================================
+:check_prereqs
+echo [..] Checking prerequisites...
+where docker >nul 2>nul
+if errorlevel 1 (
+    echo [X] Docker not found. Install Docker Desktop:
+    echo     https://www.docker.com/products/docker-desktop/
+    exit /b 1
+)
+docker info >nul 2>nul
+if errorlevel 1 (
+    echo [X] Docker daemon is not running. Start Docker Desktop.
+    exit /b 1
+)
+docker compose version >nul 2>nul
+if errorlevel 1 (
+    echo [X] Docker Compose v2 not found. Update Docker Desktop.
+    exit /b 1
+)
+echo [OK] Docker, daemon, and Compose v2 detected.
+exit /b 0
+
+rem ============================================================================
+:write_env_file
+rem Determine feed values, mock mode wins.
+if /I "%MOCK_MODE%"=="true" (
+    set "FEED_FLIGHT=mock"
+    set "SHIP_FEED=mock"
+    set "SATELLITES_ENABLED_VAL=false"
+    set "SPRING_PROFILES_VAL=mock"
+) else (
+    if "%INGESTION_FEED_FLIGHT%"=="" ( set "FEED_FLIGHT=mock" ) else ( set "FEED_FLIGHT=%INGESTION_FEED_FLIGHT%" )
+    if "%INGESTION_FEED_SHIP%"==""   ( set "SHIP_FEED=mock"   ) else ( set "SHIP_FEED=%INGESTION_FEED_SHIP%" )
+    if "%SATELLITES_ENABLED%"==""    ( set "SATELLITES_ENABLED_VAL=false" ) else ( set "SATELLITES_ENABLED_VAL=%SATELLITES_ENABLED%" )
+    set "SPRING_PROFILES_VAL=%SPRING_PROFILES_ACTIVE%"
+)
+
+if "%MOCK_SEED%"==""              set "MOCK_SEED=42"
+if "%MOCK_FLIGHTS_COUNT%"==""     set "MOCK_FLIGHTS_COUNT=500"
+if "%MOCK_SHIPS_COUNT%"==""       set "MOCK_SHIPS_COUNT=200"
+if "%MOCK_SATELLITES_COUNT%"==""  set "MOCK_SATELLITES_COUNT=100"
+if "%GATEWAY_API_KEY%"==""        set "GATEWAY_API_KEY=dev-key"
+
+rem Validate AISStream key requirement.
+if /I "%SHIP_FEED%"=="aisstream" (
+    if "%AISSTREAM_API_KEY%"=="" (
+        echo [X] AISSTREAM_API_KEY is required when INGESTION_FEED_SHIP=aisstream
+        echo     Get a free key at: https://aisstream.io
+        exit /b 1
+    )
+)
+
+if not exist "deploy" mkdir "deploy"
+
+(
+    echo # Auto-generated by run.bat — do not commit
+    echo AISSTREAM_API_KEY=%AISSTREAM_API_KEY%
+    echo OPENSKY_USERNAME=%OPENSKY_USERNAME%
+    echo OPENSKY_PASSWORD=%OPENSKY_PASSWORD%
+    echo GATEWAY_API_KEY=%GATEWAY_API_KEY%
+    echo INGESTION_FEED_FLIGHT=%FEED_FLIGHT%
+    echo INGESTION_FEED_SHIP=%SHIP_FEED%
+    echo SATELLITES_ENABLED=%SATELLITES_ENABLED_VAL%
+    echo SPRING_PROFILES_ACTIVE=%SPRING_PROFILES_VAL%
+    echo MOCK_SEED=%MOCK_SEED%
+    echo MOCK_FLIGHTS_COUNT=%MOCK_FLIGHTS_COUNT%
+    echo MOCK_SHIPS_COUNT=%MOCK_SHIPS_COUNT%
+    echo MOCK_SATELLITES_COUNT=%MOCK_SATELLITES_COUNT%
+) > "deploy\.env"
+
+echo [OK] Environment written to deploy\.env
+
+if /I "%MOCK_MODE%"=="true" (
+    echo      Mode: mock ^(deterministic, no internet required^)
+    echo      Flights:    %MOCK_FLIGHTS_COUNT% aircraft  ^(seed %MOCK_SEED%^)
+    echo      Ships:      %MOCK_SHIPS_COUNT% vessels   ^(seed %MOCK_SEED%^)
+    echo      Satellites: %MOCK_SATELLITES_COUNT% mock satellites
+) else (
+    echo      Flights:    %FEED_FLIGHT%
+    echo      Ships:      %SHIP_FEED%
+    echo      Satellites: %SATELLITES_ENABLED_VAL%
+)
+exit /b 0
+
+rem ============================================================================
+:build_images
+echo.
+echo [..] Building Docker images ^(may take several minutes on first build^)...
+docker compose -f "%COMPOSE_FILE%" build --parallel
+if errorlevel 1 (
+    echo [X] Image build failed.
+    exit /b 1
+)
+echo [OK] All images built.
+exit /b 0
+
+rem ============================================================================
+:start_services
+echo.
+echo [..] Starting services...
+docker compose -f "%COMPOSE_FILE%" up -d
+if errorlevel 1 (
+    echo [X] docker compose up failed.
+    exit /b 1
+)
+
+echo.
+echo [..] Waiting up to 120s for services to start...
+set /a ELAPSED=0
+:wait_loop
+if %ELAPSED% GEQ 120 goto :wait_done
+timeout /t 5 /nobreak >nul
+set /a ELAPSED+=5
+echo      ^(%ELAPSED%s elapsed^)
+goto :wait_loop
+:wait_done
+
+echo.
+docker compose -f "%COMPOSE_FILE%" ps
+echo.
+echo [OK] Digital Twin Earth is running!
+echo.
+echo   Frontend:  http://localhost:4200
+echo   API:       http://localhost:8080/api/flights
+echo   Health:    http://localhost:8080/actuator/health
+echo.
+echo   Stream test:
+echo     curl -H "X-Api-Key: dev-key" http://localhost:8080/api/stream/flights
+echo.
+echo   Follow logs: run.bat logs
+echo   Stop:        run.bat down
+exit /b 0
+
+rem ============================================================================
+:stop_services
+echo [..] Stopping services...
+docker compose -f "%COMPOSE_FILE%" down
+if errorlevel 1 exit /b 1
+echo [OK] All services stopped.
+exit /b 0
+
+rem ============================================================================
+:do_up
+call :check_prereqs   || goto :failure
+call :write_env_file  || goto :failure
+call :build_images    || goto :failure
+call :start_services  || goto :failure
+goto :end
+
+:do_down
+call :stop_services || goto :failure
+goto :end
+
+:do_restart
+call :stop_services   || goto :failure
+call :check_prereqs   || goto :failure
+call :write_env_file  || goto :failure
+call :start_services  || goto :failure
+goto :end
+
+:do_build
+call :check_prereqs   || goto :failure
+call :write_env_file  || goto :failure
+call :build_images    || goto :failure
+goto :end
+
+:do_logs
+docker compose -f "%COMPOSE_FILE%" logs -f --tail=100
+goto :end
+
+:do_status
+docker compose -f "%COMPOSE_FILE%" ps
+goto :end
+
+:do_clean
+echo [!] This will REMOVE all containers, networks, AND volumes ^(database data^)!
+set /p "CONFIRM=Are you sure? (y/N) "
+if /I "%CONFIRM%"=="y" (
+    docker compose -f "%COMPOSE_FILE%" down -v --remove-orphans
+    echo [OK] Cleaned up.
+) else (
+    echo [..] Cancelled.
+)
+goto :end
+
+rem ============================================================================
+:failure
+popd >nul
+endlocal
+exit /b 1
+
+:end
+popd >nul
+endlocal
+exit /b 0

--- a/vibes/opentracker/status.md
+++ b/vibes/opentracker/status.md
@@ -1,0 +1,204 @@
+# OpenTracker — Implementation Status
+
+_Last updated: 2026-05-08_
+
+This document tracks the state of every roadmap item from `AGENTS.MD §9` plus
+the surrounding feature inventory. It is the single source of truth for what
+ships in the current branch.
+
+---
+
+## Legend
+
+| Mark | Meaning                                              |
+| ---- | ---------------------------------------------------- |
+| ✅   | Implemented and exercised in this build              |
+| 🟡   | Partially implemented (works in default config only) |
+| ⏭️   | Documented future work, deliberately deferred        |
+
+---
+
+## Core stack (already shipped on `main`)
+
+| Area                      | Status | Notes                                                            |
+| ------------------------- | ------ | ---------------------------------------------------------------- |
+| Gateway service (`:8080`) | ✅     | REST + SSE fan-out, API-key filter, rate limit filter            |
+| Ingestion service         | ✅     | Mock + OpenSky + ADS-B + AISStream + AISHub + Celestrak TLE      |
+| Stream processor          | ✅     | Kafka consumer → PostgreSQL + Redis cache                        |
+| Geospatial query service  | ✅     | PostGIS bounding-box queries + track queries                     |
+| Angular SPA               | ✅     | CesiumJS 1.116, layer panel, stats panel, entity detail, search  |
+| Mock data simulators      | ✅     | Deterministic flights / ships / satellites with `MOCK_SEED`      |
+| TLE propagator            | ✅     | Pure-Java SGP4-style Keplerian propagator, no external deps      |
+| Docker compose            | ✅     | `./run.sh mock up` / `up` / `down` / `clean`                     |
+| CI                        | ✅     | `.github/workflows/ci.yml` + `build-and-push.yml`                |
+
+---
+
+## Roadmap items (AGENTS.MD §9)
+
+### 9.1 Viewport-aware SSE filtering — ⏭️
+
+**Status:** Deferred.
+**Why deferred:** The current SSE broadcaster forwards raw Kafka payloads as
+strings. Adding bbox filtering requires either parsing every event in the hot
+path or shifting filtering into Cesium-side culling. The frontend already
+performs entity-level frustum culling via `EntityCluster`, which mitigates the
+rendering cost at typical loads (≤2k entities). A first-class viewport filter
+should be revisited when the project ships a 10k+ entity benchmark scenario.
+
+### 9.2 Entity clustering at low zoom — ✅
+
+`GlobeEngineService.init()` enables `viewer.entities.cluster` with
+`pixelRange = 48` and `minimumClusterSize = 4`. The cluster event handler
+recolors and counts grouped flight/ship/satellite entities so the global view
+remains legible at any zoom level.
+
+### 9.3 3D aircraft and vessel models (GLTF) — ⏭️
+
+**Status:** Deferred.
+**Why deferred:** Requires bundling CC0 GLTF assets and a zoom-tier swap
+between `point:` and `model:` entity graphics. Out of scope for this pass to
+keep bundle size and licensing footprint stable.
+
+### 9.4 Satellite ground track visualization — ✅
+
+`GlobeEngineService.showSatelliteFootprint()` renders a footprint ellipse and
+a nadir line for the selected satellite. Track polylines are rendered for
+flights and vessels (see 9.6).
+
+### 9.5 Real-time search / geosearch — ✅
+
+`GlobeComponent.onSearchInput()` (via the `/` keyboard shortcut) does local
+entity search first, then falls back to Nominatim geocoding for places.
+Selecting a hit calls `globe.flyTo(lat, lon, alt)`.
+
+### 9.6 Track polylines on entity click — ✅
+
+`EntityDetailComponent.loadFlightTrack()` / `loadShipTrack()` calls
+`/api/{flights|ships}/{id}/track`, then `globe.renderTrack()` draws the
+returned points as a polyline. Tracks are cleared when the detail panel closes.
+
+### 9.7 TimescaleDB for track history — ✅ _(new this pass)_
+
+`backend/stream-processor/src/main/resources/db/migration/V3__timescaledb_optional.sql`
+converts `aircraft_positions` and `vessel_positions` into hypertables and
+attaches a 7-day compression policy when the TimescaleDB extension is
+available. The migration is a guarded no-op on stock PostgreSQL, so the
+default `postgres:16-3.4-alpine` image continues to work unchanged. To enable
+TimescaleDB, swap the postgres service image in `deploy/docker-compose.yml`
+to `timescale/timescaledb-ha:pg16`; Flyway will pick up the V3 migration on
+next boot.
+
+### 9.8 WebSocket upgrade path — ⏭️
+
+**Status:** Deferred.
+**Why deferred:** SSE meets every current client requirement and is simpler
+to scale horizontally behind nginx. WebSocket should land alongside the
+time-scrubbing playback feature that motivates a bidirectional channel.
+
+### 9.9 Airport and port layer — ✅ _(new this pass)_
+
+`frontend/digital-twin-earth-app/src/app/services/airports.data.ts` ships a
+curated, public-domain subset of 70+ major international airports.
+`GlobeEngineService.setAirportsVisible()` toggles them as IATA-labeled
+billboards with the orange Apple HIG accent. The toggle is wired into the
+layers panel and the `A` keyboard shortcut. The full OurAirports CSV can
+be loaded in the same shape later without UI changes.
+
+### 9.10 Keyboard shortcuts — ✅
+
+`GlobeComponent.onKeydown()` listens on `document:keydown`:
+
+| Key       | Action                       |
+| --------- | ---------------------------- |
+| `F`       | Toggle flights               |
+| `S`       | Toggle ships                 |
+| `T`       | Toggle satellites            |
+| `A`       | Toggle airports _(new)_      |
+| `H`       | Fly to home                  |
+| `R`       | Recover Earth view           |
+| `+` / `-` | Zoom in / out                |
+| `/`       | Focus search                 |
+| `Escape`  | Close panel / dismiss search |
+
+### 9.11 Cesium Ion terrain (optional) — ✅
+
+`GlobeEngineService.applyTerrainProvider()` checks `window.CESIUM_ION_TOKEN`
+or `localStorage.cesiumIonToken`. When present, it loads
+`Cesium.createWorldTerrainAsync()` and enables `depthTestAgainstTerrain`. The
+default zero-key path uses `EllipsoidTerrainProvider`. Setup guidance lives
+in `docs/IMAGERY_SETUP.md`.
+
+### 9.12 Helm chart for Kubernetes — ⏭️
+
+**Status:** Deferred.
+**Why deferred:** docker-compose covers the local stress-test story today.
+Helm should land paired with the Zing benchmark publication so charts and
+manifests are validated together rather than written speculatively.
+
+### 9.13 GeoJSON / CSV export — ✅ _(new this pass)_
+
+`backend/gateway/.../controller/ExportController.java` exposes:
+
+| Endpoint                                  | Returns                          |
+| ----------------------------------------- | -------------------------------- |
+| `GET /api/export/flights.geojson?bbox=…`  | `FeatureCollection` of flights   |
+| `GET /api/export/ships.geojson?bbox=…`    | `FeatureCollection` of vessels   |
+| `GET /api/export/satellites.geojson`      | `FeatureCollection` of satellites |
+
+Each response sets `Content-Disposition: attachment` and uses the
+`application/geo+json` MIME type so QGIS, Mapbox, and Kepler.gl consume it
+out of the box. The frontend exposes one-click downloads in the stats panel
+(`Export · Flights · Ships · Sats`).
+
+---
+
+## Quick verification checklist
+
+```bash
+# Build everything (skips tests)
+./gradlew build -x test
+
+# Bring the stack up in mock mode
+./run.sh mock up
+
+# Smoke-test the new export endpoints
+curl -H 'X-Api-Key: dev-key' -o flights.geojson \
+     'http://localhost:8080/api/export/flights.geojson'
+curl -H 'X-Api-Key: dev-key' -o ships.geojson \
+     'http://localhost:8080/api/export/ships.geojson'
+
+# Open the SPA, hit "A" to toggle the airports layer,
+# click "Export · Flights" in the stats panel.
+```
+
+---
+
+## Files added or modified in this pass
+
+```
+backend/gateway/src/main/java/com/digitaltwin/gateway/controller/ExportController.java   (new)
+backend/stream-processor/src/main/resources/db/migration/V3__timescaledb_optional.sql    (new)
+frontend/digital-twin-earth-app/src/app/services/airports.data.ts                        (new)
+frontend/digital-twin-earth-app/src/app/services/globe-engine.service.ts                 (airport layer + lifecycle)
+frontend/digital-twin-earth-app/src/app/globe/globe.component.ts                         (airport toggle + 'A' shortcut)
+frontend/digital-twin-earth-app/src/app/globe/globe.component.html                       (pass showAirports input)
+frontend/digital-twin-earth-app/src/app/globe/layer-toggle/layer-toggle.component.ts     (showAirports input)
+frontend/digital-twin-earth-app/src/app/globe/layer-toggle/layer-toggle.component.html   (airport toggle row)
+frontend/digital-twin-earth-app/src/app/globe/layer-toggle/layer-toggle.component.scss   (airport indicator styling)
+frontend/digital-twin-earth-app/src/app/globe/stats-panel/stats-panel.component.ts       (export action)
+frontend/digital-twin-earth-app/src/app/globe/stats-panel/stats-panel.component.html     (export row)
+frontend/digital-twin-earth-app/src/app/globe/stats-panel/stats-panel.component.scss     (export styling)
+status.md                                                                                (this file)
+```
+
+---
+
+## Next-up suggestions
+
+1. **9.1 Viewport-aware SSE filtering** — biggest scalability lift; cleanest
+   implementation introduces a typed `PositionEnvelope` Kafka payload so the
+   gateway can filter without re-parsing JSON.
+2. **9.3 3D models** — most user-facing visual upgrade; bundle a single
+   shared CC0 jet GLTF and one hull GLTF, pick by zoom altitude.
+3. **9.12 Helm chart** — required to land the Zing benchmark publication.


### PR DESCRIPTION
Closes the higher-leverage AGENTS.MD §9 roadmap items and adds a Windows-native runner so the stack can be built and run end-to-end without WSL.

- 9.13 GeoJSON export: new /api/export/{flights,ships,satellites}.geojson on the gateway, with one-click downloads in the stats panel.
- 9.9 Airport layer: curated public-domain set of 70+ major hubs, toggleable from the layer panel and via the new "A" keybinding.
- 9.7 TimescaleDB: guarded V3 Flyway migration that converts the position tables to compressed hypertables when the extension exists, no-op on stock PostgreSQL.
- run.bat mirrors run.sh on Windows (mock/up/down/restart/build/logs/ status/clean), validates Docker Desktop, generates deploy/.env, and delegates dependency resolution to the existing Dockerfiles.
- status.md tracks per-item state and rationale for the items still deferred (viewport SSE, GLTF models, WebSocket, Helm).